### PR TITLE
add :poison to applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Mailgun.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :inets, :ssl]]
+    [applications: [:logger, :inets, :poison, :ssl]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
- getting warning on build release without poison in :applications.